### PR TITLE
Add audit functionality to aggregates; enhance repository save logic …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,24 @@
 
 # es
 
-A comprehensive event sourcing library for Go providing clean, extensible interfaces for building event-driven applications.
+A focused event sourcing library for Go: aggregates, domain events, a `Store` contract, repository load/save, optional **audit batch streams**, and OpenTelemetry hooks.
+
+## Documentation
+
+| Resource | Description |
+|----------|-------------|
+| [docs/README.md](docs/README.md) | Overview, mental model, principles, doc index |
+| [docs/getting-started.md](docs/getting-started.md) | Walkthrough: events, aggregate, repository |
+| [docs/api-reference.md](docs/api-reference.md) | Interfaces, factories, types, patterns |
+| [docs/audit_events.md](docs/audit_events.md) | `Audit` vs `Raise`, persistence order, consumers |
 
 ## Features
 
 - **Aggregate Roots**: Event-sourced aggregates with automatic event registration and replay
 - **Event Handling**: Type-safe event handlers with generic registration
-- **Event Storage**: Pluggable event store interface with in-memory implementation
+- **Event storage**: `Store` interface in this module; **production implementations live in your codebase**; `NewInMemoryEventStore` for tests and local development
 - **Repository Pattern**: High-level aggregate persistence with optimistic concurrency control
+- **Derived audit streams**: `Aggregate.Audit` stages immutable `DomainEvent` rows on fresh batch streams derived from the current aggregate (not replayed on `Load`); `Repository.Save` persists audits before domain events
 - **Multi-tenancy**: Support for global and tenant-scoped aggregates
 - **Context Propagation**: Built-in correlation and causation tracking
 - **OpenTelemetry Spans**: Repository load and save operations emit OTEL spans with aggregate metadata
@@ -91,14 +101,16 @@ type CatRenamed struct {
 }
 
 func (e *CatRenamed) GetDiscriminator() string { return "cat.renamed" }
-func (e *CatRenamed) GetSpaces() []string      { return []string{"cats"} }
+func (e *CatRenamed) GetAreas() []string         { return []string{"cats"} }
+func (e *CatRenamed) GetSpaces() []string        { return e.GetAreas() }
 
 type CatAdopted struct {
 	es.DomainEventBase
 }
 
 func (e *CatAdopted) GetDiscriminator() string { return "cat.adopted" }
-func (e *CatAdopted) GetSpaces() []string      { return []string{"cats"} }
+func (e *CatAdopted) GetAreas() []string         { return []string{"cats"} }
+func (e *CatAdopted) GetSpaces() []string        { return e.GetAreas() }
 ```
 
 ### 3. Use the Repository
@@ -176,7 +188,7 @@ Aggregate wiring is intentionally fail-fast in this library. The default aggrega
 - missing aggregate IDs or tenant IDs
 - empty aggregate areas
 - duplicate handler registration
-- event types whose `GetSpaces()` do not include the aggregate area
+- event types whose `GetAreas()` do not include the aggregate area
 
 These are treated as programmer errors in aggregate design, not recoverable runtime conditions. Business-rule failures should still be returned from your command methods as ordinary `error` values.
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Aggregate wiring is intentionally fail-fast in this library. The default aggrega
 - missing aggregate IDs or tenant IDs
 - empty aggregate areas
 - duplicate handler registration
-- event types whose `GetAreas()` do not include the aggregate area
+- event types whose effective area list does not include the aggregate area
 
 These are treated as programmer errors in aggregate design, not recoverable runtime conditions. Business-rule failures should still be returned from your command methods as ordinary `error` values.
 

--- a/aggregate.go
+++ b/aggregate.go
@@ -16,9 +16,9 @@ const (
 	errRegisterHandlerNilType        = "RegisterHandler: event type must be concrete"
 	errNewTenantAggregateNilTenantID = "NewTenantAggregate: tenantID must not be nil"
 	errNewAggregateNilID             = "newAggregate: id cannot be nil"
-	errNewAggregateEmptySpace        = "newAggregate: space cannot be empty"
-	errRaiseInvalidAggregateSpace    = "Raise: aggregate space '%s' is not valid for event %T"
-	errAuditInvalidAggregateSpace    = "Audit: aggregate space '%s' is not valid for event %T"
+	errNewAggregateEmptyArea         = "newAggregate: area cannot be empty"
+	errRaiseInvalidAggregateArea     = "Raise: aggregate area '%s' is not valid for event %T"
+	errAuditInvalidAggregateArea     = "Audit: aggregate area '%s' is not valid for event %T"
 )
 
 // DomainEventHandler defines a function that handles a domain event.
@@ -63,6 +63,10 @@ func newEventInstance[T DomainEvent]() T {
 }
 
 // Aggregate defines the interface for event-sourced aggregates.
+//
+// Note: the audit methods on this interface are a deliberate breaking API change
+// in this branch; external aggregate implementations must be updated together
+// with the audit workflow changes.
 // Aggregates are the primary building blocks of event sourcing, representing
 // business entities that generate and respond to domain events.
 //
@@ -94,7 +98,7 @@ type Aggregate interface {
 	Load([]DomainEvent) error
 	Commit()
 
-	// PendingAudits returns a copy of staged audit events (metadata is applied on Repository.Save).
+	// GetPendingAudits returns a copy of staged audit events (metadata is applied on Repository.Save).
 	GetPendingAudits() []PendingAudit
 	// DiscardPendingAudits clears staged audits. The repository calls this after
 	// those audits have been persisted successfully (or use TrimPendingAudits incrementally).
@@ -136,7 +140,7 @@ func newAggregate(ctx context.Context, scope Scope, area string, tenantID, id uu
 		panic(errNewAggregateNilID)
 	}
 	if area == "" {
-		panic(errNewAggregateEmptySpace)
+		panic(errNewAggregateEmptyArea)
 	}
 
 	entity := Entity{
@@ -187,8 +191,13 @@ func (a *aggregateBase) GetAggregateID() uuid.UUID {
 	return a.entity.ID
 }
 
-func (a *aggregateBase) GetAggregateSpace() string {
+func (a *aggregateBase) GetAggregateArea() string {
 	return a.entity.Area
+}
+
+// GetAggregateSpace is deprecated. Use GetAggregateArea.
+func (a *aggregateBase) GetAggregateSpace() string {
+	return a.GetAggregateArea()
 }
 
 func (a *aggregateBase) GetCorrelationID() uuid.UUID {
@@ -271,8 +280,8 @@ func (a *aggregateBase) RegisterHandler(discriminator string, handler DomainEven
 // are treated as design-time wiring errors.
 func (a *aggregateBase) Raise(event DomainEvent) error {
 	domainArea := a.entity.Area
-	if !eventListsSpace(event, domainArea) {
-		panic(fmt.Sprintf(errRaiseInvalidAggregateSpace, domainArea, event))
+	if !eventListsArea(event, domainArea) {
+		panic(fmt.Sprintf(errRaiseInvalidAggregateArea, domainArea, event))
 	}
 
 	event.SetMetadata(EventMetadata{
@@ -296,8 +305,11 @@ func (a *aggregateBase) Raise(event DomainEvent) error {
 // The event's GetAreas() must include the domain aggregate area.
 func (a *aggregateBase) Audit(event DomainEvent) error {
 	domainArea := a.entity.Area
-	if !eventListsSpace(event, domainArea) {
-		panic(fmt.Sprintf(errAuditInvalidAggregateSpace, domainArea, event))
+	if !eventListsArea(event, domainArea) {
+		panic(fmt.Sprintf(errAuditInvalidAggregateArea, domainArea, event))
+	}
+	if eventAlreadyStaged(a.pendingAudits, event) {
+		panic("Audit: event instance must not be staged more than once")
 	}
 
 	auditEntity := AuditStreamEntity(a.entity)
@@ -313,12 +325,41 @@ func (a *aggregateBase) Audit(event DomainEvent) error {
 	return nil
 }
 
-func eventListsSpace(event DomainEvent, area string) bool {
-	for _, s := range event.GetAreas() {
-		if s == area {
+func eventListsArea(event DomainEvent, area string) bool {
+	for _, candidate := range eventAreas(event) {
+		if candidate == area {
 			return true
 		}
 	}
+	return false
+}
+
+func eventAlreadyStaged(pending []PendingAudit, event DomainEvent) bool {
+	if event == nil {
+		return false
+	}
+
+	eventValue := reflect.ValueOf(event)
+	if eventValue.Kind() != reflect.Pointer || eventValue.IsNil() {
+		return false
+	}
+
+	eventPtr := eventValue.Pointer()
+	for _, staged := range pending {
+		if staged.Event == nil {
+			continue
+		}
+
+		stagedValue := reflect.ValueOf(staged.Event)
+		if stagedValue.Kind() != reflect.Pointer || stagedValue.IsNil() {
+			continue
+		}
+
+		if stagedValue.Pointer() == eventPtr {
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/aggregate.go
+++ b/aggregate.go
@@ -18,6 +18,7 @@ const (
 	errNewAggregateNilID             = "newAggregate: id cannot be nil"
 	errNewAggregateEmptySpace        = "newAggregate: space cannot be empty"
 	errRaiseInvalidAggregateSpace    = "Raise: aggregate space '%s' is not valid for event %T"
+	errAuditInvalidAggregateSpace    = "Audit: aggregate space '%s' is not valid for event %T"
 )
 
 // DomainEventHandler defines a function that handles a domain event.
@@ -27,7 +28,7 @@ type DomainEventHandler func(DomainEvent)
 type HandlerFactory func(Aggregate) DomainEventHandler
 
 // RegisterHandler registers a typed event handler for a specific event type on an aggregate.
-// The handler will be called when the event type is raised or loaded.
+// The handler will be called when the event type is raised or loaded, but not for Audit.
 // This function panics on invalid aggregate wiring such as nil handlers,
 // duplicate handlers, or invalid event type parameters.
 func RegisterHandler[T DomainEvent](a Aggregate, handler func(T)) {
@@ -89,8 +90,27 @@ type Aggregate interface {
 	// Event behavior
 	RegisterHandler(string, DomainEventHandler)
 	Raise(DomainEvent) error
+	Audit(DomainEvent) error
 	Load([]DomainEvent) error
 	Commit()
+
+	// PendingAudits returns a copy of staged audit events (metadata is applied on Repository.Save).
+	GetPendingAudits() []PendingAudit
+	// DiscardPendingAudits clears staged audits. The repository calls this after
+	// those audits have been persisted successfully (or use TrimPendingAudits incrementally).
+	DiscardPendingAudits()
+	// TrimPendingAudits removes the first n staged audits. Repository.Save calls this
+	// after each successful audit batch; application code should not use it.
+	TrimPendingAudits(n int)
+}
+
+// PendingAudit is an audit event staged on the aggregate before Repository.Save.
+// Event metadata is filled when the repository persists to the audit stream.
+type PendingAudit struct {
+	Event     DomainEvent
+	Entity    Entity
+	EventID   uuid.UUID
+	Timestamp int64
 }
 
 // NewAggregate creates a new global-scoped aggregate with the specified area and ID.
@@ -155,6 +175,7 @@ type aggregateBase struct {
 	causationID   uuid.UUID
 	committed     []DomainEvent
 	uncommitted   []DomainEvent
+	pendingAudits []PendingAudit
 	handlers      map[string]DomainEventHandler
 }
 
@@ -207,6 +228,26 @@ func (a *aggregateBase) Commit() {
 	a.uncommitted = make([]DomainEvent, 0)
 }
 
+func (a *aggregateBase) GetPendingAudits() []PendingAudit {
+	out := make([]PendingAudit, len(a.pendingAudits))
+	copy(out, a.pendingAudits)
+	return out
+}
+
+func (a *aggregateBase) DiscardPendingAudits() {
+	a.pendingAudits = nil
+}
+
+func (a *aggregateBase) TrimPendingAudits(n int) {
+	if n <= 0 {
+		return
+	}
+	if n > len(a.pendingAudits) {
+		n = len(a.pendingAudits)
+	}
+	a.pendingAudits = a.pendingAudits[n:]
+}
+
 // ApplyEvent provides default behavior - overridden by concrete types
 func (a *aggregateBase) applyEvent(event DomainEvent) {
 	eventName := event.GetDiscriminator()
@@ -229,7 +270,11 @@ func (a *aggregateBase) RegisterHandler(discriminator string, handler DomainEven
 // definition is not valid for the aggregate because invalid event-area mappings
 // are treated as design-time wiring errors.
 func (a *aggregateBase) Raise(event DomainEvent) error {
-	// Set event metadata
+	domainArea := a.entity.Area
+	if !eventListsSpace(event, domainArea) {
+		panic(fmt.Sprintf(errRaiseInvalidAggregateSpace, domainArea, event))
+	}
+
 	event.SetMetadata(EventMetadata{
 		Entity:        a.GetEntity(),
 		EventID:       uuid.New(),
@@ -239,24 +284,42 @@ func (a *aggregateBase) Raise(event DomainEvent) error {
 		Sequence:      a.GetUncommittedSequence() + 1,
 	})
 
-	// Validate aggregate space
-	validSpaces := event.GetSpaces()
-	aggregateSpace := event.GetArea()
-	isValid := false
-	for _, space := range validSpaces {
-		if space == aggregateSpace {
-			isValid = true
-			break
-		}
-	}
-	if !isValid {
-		panic(fmt.Sprintf(errRaiseInvalidAggregateSpace, aggregateSpace, event))
-	}
-
-	// Apply event and append to uncommitted
 	a.applyEvent(event)
 	a.AppendUncommitted(event)
 	return nil
+}
+
+// Audit stages an immutable audit fact for a derived batch stream (see AuditStreamEntity)
+// or for a stream resolved by Repository WithAuditRouter. It does not run domain handlers,
+// does not append to uncommitted events, and is never replayed by Load.
+//
+// The event's GetAreas() must include the domain aggregate area.
+func (a *aggregateBase) Audit(event DomainEvent) error {
+	domainArea := a.entity.Area
+	if !eventListsSpace(event, domainArea) {
+		panic(fmt.Sprintf(errAuditInvalidAggregateSpace, domainArea, event))
+	}
+
+	auditEntity := AuditStreamEntity(a.entity)
+	if len(a.pendingAudits) > 0 {
+		auditEntity = a.pendingAudits[0].Entity
+	}
+	a.pendingAudits = append(a.pendingAudits, PendingAudit{
+		Event:     event,
+		Entity:    auditEntity,
+		EventID:   uuid.New(),
+		Timestamp: timestamp.GetTimestamp(),
+	})
+	return nil
+}
+
+func eventListsSpace(event DomainEvent, area string) bool {
+	for _, s := range event.GetAreas() {
+		if s == area {
+			return true
+		}
+	}
+	return false
 }
 
 // Load replays committed events onto an aggregate

--- a/aggregate.go
+++ b/aggregate.go
@@ -298,8 +298,8 @@ func (a *aggregateBase) Raise(event DomainEvent) error {
 	return nil
 }
 
-// Audit stages an immutable audit fact for a derived batch stream (see AuditStreamEntity)
-// or for a stream resolved by Repository WithAuditRouter. It does not run domain handlers,
+// Audit stages an immutable audit fact for a derived batch stream (see AuditStreamEntity).
+// It does not run domain handlers,
 // does not append to uncommitted events, and is never replayed by Load.
 //
 // The event's GetAreas() must include the domain aggregate area.

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -146,6 +146,59 @@ func TestShouldPanicWhenRaisingEventWithInvalidArea(t *testing.T) {
 	assert.Len(t, dummy.GetUncommittedEvents(), 0)
 }
 
+func TestShouldPanicWhenAuditingWithInvalidArea(t *testing.T) {
+	dummy := NewDummy()
+
+	assert.Panics(t, func() {
+		_ = dummy.Audit(&WrongAreaDummyCreated{})
+	})
+	assert.Len(t, dummy.GetPendingAudits(), 0)
+}
+
+func TestShouldStageAuditWithoutRunningDomainHandlers(t *testing.T) {
+	dummy := NewDummy()
+
+	err := dummy.Audit(&DummyAuditLogged{Reason: "login"})
+
+	assert.NoError(t, err)
+	assert.Empty(t, dummy.GetUncommittedEvents())
+	assert.Len(t, dummy.GetPendingAudits(), 1)
+	assert.Equal(t, "", dummy.name)
+}
+
+func TestShouldReturnIndependentPendingAuditCopies(t *testing.T) {
+	dummy := NewDummy()
+	_ = dummy.Audit(&DummyAuditLogged{Reason: "a"})
+
+	first := dummy.GetPendingAudits()
+	assert.Len(t, first, 1)
+	first = append(first, PendingAudit{EventID: uuid.New()})
+	assert.Len(t, first, 2)
+	assert.Len(t, dummy.GetPendingAudits(), 1)
+}
+
+func TestShouldReuseAuditBatchUntilDiscarded(t *testing.T) {
+	dummy := NewDummy()
+	_ = dummy.LogAudit("one")
+	_ = dummy.LogAudit("two")
+
+	pending := dummy.GetPendingAudits()
+	assert.Len(t, pending, 2)
+	assert.Equal(t, pending[0].Entity, pending[1].Entity)
+	assert.NotEqual(t, uuid.Nil, pending[0].Entity.ID)
+	assert.NotEqual(t, dummy.GetEntity().ID, pending[0].Entity.ID)
+	assert.Equal(t, dummy.GetEntity().Area, pending[0].Entity.Area)
+
+	firstBatchID := pending[0].Entity.ID
+	dummy.DiscardPendingAudits()
+	_ = dummy.LogAudit("three")
+
+	next := dummy.GetPendingAudits()
+	assert.Len(t, next, 1)
+	assert.NotEqual(t, firstBatchID, next[0].Entity.ID)
+	assert.Equal(t, dummy.GetEntity().Area, next[0].Entity.Area)
+}
+
 type DummyCreated struct {
 	DomainEventBase
 	Name string
@@ -160,7 +213,8 @@ type WrongAreaDummyCreated struct {
 }
 
 func (e *DummyCreated) GetDiscriminator() string { return "dummy_created" }
-func (e *DummyCreated) GetSpaces() []string      { return []string{AreaTest, AreaDummy} }
+func (e *DummyCreated) GetAreas() []string       { return []string{AreaTest, AreaDummy} }
+func (e *DummyCreated) GetSpaces() []string      { return e.GetAreas() }
 
 func (e *panicOnNilDiscriminatorEvent) GetDiscriminator() string {
 	if e == nil {
@@ -170,10 +224,23 @@ func (e *panicOnNilDiscriminatorEvent) GetDiscriminator() string {
 	return "panic_on_nil_discriminator"
 }
 
-func (e *panicOnNilDiscriminatorEvent) GetSpaces() []string { return []string{AreaDummy} }
+func (e *panicOnNilDiscriminatorEvent) GetAreas() []string { return []string{AreaDummy} }
+func (e *panicOnNilDiscriminatorEvent) GetSpaces() []string {
+	return e.GetAreas()
+}
 
 func (e *WrongAreaDummyCreated) GetDiscriminator() string { return "wrong_area_dummy_created" }
-func (e *WrongAreaDummyCreated) GetSpaces() []string      { return []string{AreaTest} }
+func (e *WrongAreaDummyCreated) GetAreas() []string       { return []string{AreaTest} }
+func (e *WrongAreaDummyCreated) GetSpaces() []string      { return e.GetAreas() }
+
+type DummyAuditLogged struct {
+	DomainEventBase
+	Reason string
+}
+
+func (e *DummyAuditLogged) GetDiscriminator() string { return "dummy_audit_logged" }
+func (e *DummyAuditLogged) GetAreas() []string       { return []string{AreaDummy} }
+func (e *DummyAuditLogged) GetSpaces() []string      { return e.GetAreas() }
 
 func NewDummy() *Dummy {
 	id := uuid.New()
@@ -192,6 +259,10 @@ func (a *Dummy) Create(name string) error {
 		return a.Raise(&DummyCreated{Name: name})
 	}
 	return nil
+}
+
+func (a *Dummy) LogAudit(reason string) error {
+	return a.Audit(&DummyAuditLogged{Reason: reason})
 }
 
 func (a *Dummy) OnDummyCreated(e *DummyCreated) {

--- a/aggregate_test.go
+++ b/aggregate_test.go
@@ -147,8 +147,10 @@ func TestShouldPanicWhenRaisingEventWithInvalidArea(t *testing.T) {
 }
 
 func TestShouldPanicWhenAuditingWithInvalidArea(t *testing.T) {
+	// Arrange
 	dummy := NewDummy()
 
+	// Act & Assert
 	assert.Panics(t, func() {
 		_ = dummy.Audit(&WrongAreaDummyCreated{})
 	})
@@ -156,10 +158,13 @@ func TestShouldPanicWhenAuditingWithInvalidArea(t *testing.T) {
 }
 
 func TestShouldStageAuditWithoutRunningDomainHandlers(t *testing.T) {
+	// Arrange
 	dummy := NewDummy()
 
+	// Act
 	err := dummy.Audit(&DummyAuditLogged{Reason: "login"})
 
+	// Assert
 	assert.NoError(t, err)
 	assert.Empty(t, dummy.GetUncommittedEvents())
 	assert.Len(t, dummy.GetPendingAudits(), 1)
@@ -167,22 +172,30 @@ func TestShouldStageAuditWithoutRunningDomainHandlers(t *testing.T) {
 }
 
 func TestShouldReturnIndependentPendingAuditCopies(t *testing.T) {
+	// Arrange
 	dummy := NewDummy()
 	_ = dummy.Audit(&DummyAuditLogged{Reason: "a"})
 
+	// Act
 	first := dummy.GetPendingAudits()
 	assert.Len(t, first, 1)
 	first = append(first, PendingAudit{EventID: uuid.New()})
+
+	// Assert
 	assert.Len(t, first, 2)
 	assert.Len(t, dummy.GetPendingAudits(), 1)
 }
 
 func TestShouldReuseAuditBatchUntilDiscarded(t *testing.T) {
+	// Arrange
 	dummy := NewDummy()
 	_ = dummy.LogAudit("one")
 	_ = dummy.LogAudit("two")
 
+	// Act
 	pending := dummy.GetPendingAudits()
+
+	// Assert
 	assert.Len(t, pending, 2)
 	assert.Equal(t, pending[0].Entity, pending[1].Entity)
 	assert.NotEqual(t, uuid.Nil, pending[0].Entity.ID)

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ This folder is the **canonical guide** for the [`github.com/fgrzl/es`](https://g
 - **`Store`** — append and read events by `Entity` (stream key), with optimistic concurrency on `SaveEvents`.
 - **`Repository`** — `Load` / `Save` for one **domain** aggregate stream; `Save` also flushes **pending audits** to separate **audit batch streams** before appending domain events.
 - **`Aggregate`** — replay (`Load`), `Raise` (domain handlers + uncommitted), `Audit` (stage only; no replay into aggregate).
-- **`DomainEvent`** — polymorphic events + metadata; **`GetAreas()`** lists allowed aggregate **areas** for wiring; **`GetSpaces()`** is deprecated and should delegate to `GetAreas()`.
+- **`DomainEvent`** — polymorphic events + metadata; **`GetSpaces()`** is the compatibility contract, and new event types should also implement **`GetAreas()`** for wiring; the package prefers `GetAreas()` when present.
 
 Production **`Store` implementations** (Postgres, EventStoreDB, Kafka-backed logs, etc.) **live in your repos**, not in `es`. This module defines the **`Store` interface** and ships **`NewInMemoryEventStore`** for tests and local development only.
 
@@ -44,7 +44,7 @@ Production **`Store` implementations** (Postgres, EventStoreDB, Kafka-backed log
 
 ## Design principles (summary)
 
-- **Fail-fast wiring** — invalid aggregate ids, duplicate handlers, or events whose `GetAreas()` omit the aggregate’s `Area` surface as panics in the default implementation (design-time mistakes).
+- **Fail-fast wiring** — invalid aggregate ids, duplicate handlers, or events whose effective area list omits the aggregate’s `Area` surface as panics in the default implementation (design-time mistakes).
 - **Metadata honesty** — persisted audit rows use `EventMetadata.Entity` for the **audit batch stream** (new stream id per batch), not the business root; link subjects via correlation and payload.
 - **Replay purity** — audit volume does not affect aggregate reconstruction.
 - **Tracing** — repository operations emit OpenTelemetry spans; pass correlation/causation via `ContextWithTracing` where needed.
@@ -57,7 +57,7 @@ Production **`Store` implementations** (Postgres, EventStoreDB, Kafka-backed log
 
 ## Best practices (short)
 
-- Implement **`GetAreas()`** on every event type; keep **`GetSpaces() = GetAreas()`** until you drop deprecated API in a major version.
+- Implement **`GetAreas()`** on every event type; keep **`GetSpaces() = GetAreas()`** until you drop the compatibility path in a major version.
 - Put **subject / origin ids in audit payloads** when downstream needs them; do not overload `GetAggregateID()` on audits.
 - Treat **`Repository.Save`** as **not** one atomic transaction across audit + domain unless your `Store` implements that.
 - Test aggregates through **command methods**; use the in-memory store for unit tests.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,89 +1,72 @@
-# Event Sourcing Documentation
+# Event sourcing (`es`) — documentation
 
-This directory contains comprehensive documentation for the `es` event sourcing library.
+This folder is the **canonical guide** for the [`github.com/fgrzl/es`](https://github.com/fgrzl/es) library: aggregates, domain events, audit batch streams, repository behavior, and how `Store` fits in.
 
-## Architecture Overview
+## Contents
 
-The library is built around several core concepts:
+| Doc | Purpose |
+|-----|---------|
+| [Getting started](getting-started.md) | Walkthrough: events with `GetAreas`, aggregate, repository, tests |
+| [API reference](api-reference.md) | Interfaces, factories, types, errors, usage snippets |
+| [Audit events](audit_events.md) | `Audit` vs `Raise`, batch streams, save order, consumers, philosophy |
 
-### 1. Aggregates
-Aggregates are the main building blocks that represent business entities. They:
-- Encapsulate business logic and maintain state
-- Generate domain events when state changes occur
-- Provide event handlers to reconstruct state from events
-- Support both global and tenant-scoped instances
+## What the library is
 
-### 2. Domain Events
-Events are immutable records that represent facts about what happened:
-- Implement the `DomainEvent` interface
-- Include rich metadata (correlation ID, causation ID, timestamps)
-- Support polymorphic serialization for persistence
-- Enable event replay and aggregate reconstruction
+`es` is a **small, opinionated core** for event-sourced aggregates in Go:
 
-### 3. Event Store
-The event store provides persistence for domain events:
-- Interface-based design supports multiple implementations
-- Optimistic concurrency control prevents conflicts
-- Sequence-based ordering ensures event consistency
-- Built-in filtering by sequence number
+- **`Store`** — append and read events by `Entity` (stream key), with optimistic concurrency on `SaveEvents`.
+- **`Repository`** — `Load` / `Save` for one **domain** aggregate stream; `Save` also flushes **pending audits** to separate **audit batch streams** before appending domain events.
+- **`Aggregate`** — replay (`Load`), `Raise` (domain handlers + uncommitted), `Audit` (stage only; no replay into aggregate).
+- **`DomainEvent`** — polymorphic events + metadata; **`GetAreas()`** lists allowed aggregate **areas** for wiring; **`GetSpaces()`** is deprecated and should delegate to `GetAreas()`.
 
-### 4. Repository Pattern
-Repositories provide high-level aggregate operations:
-- Load aggregates from event streams
-- Save uncommitted events with conflict detection
-- Automatic event application and state reconstruction
-- Transaction-like semantics with commit operations
+Production **`Store` implementations** (Postgres, EventStoreDB, Kafka-backed logs, etc.) **live in your repos**, not in `es`. This module defines the **`Store` interface** and ships **`NewInMemoryEventStore`** for tests and local development only.
 
-## Design Principles
+## Architecture (mental model)
 
-### Type Safety
-- Generic event handler registration prevents runtime errors
-- Compile-time type checking for event handlers
-- Strong typing throughout the API surface
+```text
+                    ┌──────────────┐
+                    │   Context    │  correlation / causation (optional)
+                    └──────┬───────┘
+                           │
+    Command ──► Aggregate (domain Entity) ──► Raise ──► uncommitted ──┐
+           │                         │                               │
+           │                         └──► Audit ──► pendingAudits ─────┤
+           │                                                           │
+           └──────────────────────────────► Repository.Save ──────────┤
+                                              │                         │
+                         audit batch Entity(s) │                         │ domain Entity
+                                              ▼                         ▼
+                                         Store.SaveEvents         Store.SaveEvents
+                                         (expectedSeq 0)          (expectedSeq = committed len)
+```
 
-### Fail-Fast Wiring
-- Aggregate construction and handler registration are treated as design-time concerns
-- Invalid aggregate IDs, tenant IDs, duplicate handlers, and invalid event-area mappings panic immediately
-- Business-rule failures should still be returned from command methods as ordinary errors
+`Repository.Load` reads **only** the domain `Entity` stream. Audit batch streams are **never** passed into `Load`.
 
-### Extensibility
-- Interface-based design allows custom implementations
-- Pluggable event stores for different persistence needs
-- Customizable aggregate behaviors
+## Design principles (summary)
 
-### Multi-tenancy
-- Built-in support for tenant-scoped aggregates
-- Tenant isolation at the entity level
-- Consistent patterns for global and tenant operations
+- **Fail-fast wiring** — invalid aggregate ids, duplicate handlers, or events whose `GetAreas()` omit the aggregate’s `Area` surface as panics in the default implementation (design-time mistakes).
+- **Metadata honesty** — persisted audit rows use `EventMetadata.Entity` for the **audit batch stream** (new stream id per batch), not the business root; link subjects via correlation and payload.
+- **Replay purity** — audit volume does not affect aggregate reconstruction.
+- **Tracing** — repository operations emit OpenTelemetry spans; pass correlation/causation via `ContextWithTracing` where needed.
 
-### Performance
-- Minimal allocations in hot paths
-- Efficient event filtering and loading
-- Thread-safe concurrent operations
+## Where to go next
 
-## Best Practices
+1. Read [Getting started](getting-started.md) if you are new to the API shape.
+2. Use [API reference](api-reference.md) while coding against interfaces.
+3. Read [Audit events](audit_events.md) before mixing `Audit` with domain `Save` semantics or building projections over audit streams.
 
-### Event Design
-- Keep events immutable and side-effect free
-- Include all necessary data in the event payload
-- Use descriptive discriminator names
-- Version events for schema evolution
+## Best practices (short)
 
-### Aggregate Design
-- Keep aggregates focused on a single business concept
-- Implement business invariants in command methods
-- Use event handlers only for state application
-- Avoid external dependencies in aggregate logic
+- Implement **`GetAreas()`** on every event type; keep **`GetSpaces() = GetAreas()`** until you drop deprecated API in a major version.
+- Put **subject / origin ids in audit payloads** when downstream needs them; do not overload `GetAggregateID()` on audits.
+- Treat **`Repository.Save`** as **not** one atomic transaction across audit + domain unless your `Store` implements that.
+- Test aggregates through **command methods**; use the in-memory store for unit tests.
 
-### Error Handling
-- Use standard error types provided by the library for store and integration failures
-- Handle concurrency conflicts gracefully
-- Validate business rules before raising events
-- Return early on validation failures
-- Treat aggregate wiring panics as programmer errors to fix rather than runtime conditions to recover from
+## Testing
 
-### Testing
-- Test business logic through aggregate methods
-- Use behavioral test naming conventions
-- Mock external dependencies
-- Test error conditions and edge cases
+- Prefer **`es.NewInMemoryEventStore()`** in tests.
+- Naming: behavioral test names (`TestShould…`) match the style used in this repository.
+
+## Contributing
+
+See the root [README](../README.md) for CI, tests (`go test ./...`), and contribution expectations.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,6 +17,8 @@ Complete reference documentation for the `es` event sourcing library.
 
 The main interface for event-sourced aggregates.
 
+Note: the audit methods on `Aggregate` are part of a deliberate breaking API update in this branch. If you implement `Aggregate` outside this package, update those implementations together with the audit workflow changes.
+
 The default `aggregateBase` implementation is intentionally fail-fast for aggregate design-time mistakes. Invalid constructor inputs, duplicate handler registration, invalid handler type parameters, and invalid event-area mappings panic immediately instead of being treated as recoverable runtime errors.
 
 ```go
@@ -76,8 +78,6 @@ type DomainEvent interface {
     polymorphic.Polymorphic
     GetAggregateID() uuid.UUID
     GetArea() string
-    GetAreas() []string
-    // Deprecated: use GetAreas
     GetSpaces() []string
     GetTenantID() uuid.UUID
     GetCausationID() uuid.UUID
@@ -91,7 +91,7 @@ type DomainEvent interface {
 }
 ```
 
-**`GetArea`, `GetAreas`, and deprecated `GetSpaces`:** `GetArea()` reflects the aggregate **area** on the event’s current metadata (after `Raise` / `Repository.Save` stamping, it matches the stream’s `Entity.Area`). `GetAreas()` is the **wiring list**: every event type must return at least the aggregate area(s) where `Raise` and `Audit` are allowed; the default aggregate checks that the aggregate’s `Entity.Area` appears in that slice. `GetSpaces()` must return the same values as `GetAreas()` and exists only for backward compatibility—delegate `GetSpaces()` to `GetAreas()` on new code.
+**`GetArea`, `GetSpaces`, and preferred `GetAreas`:** `GetArea()` reflects the aggregate **area** on the event’s current metadata (after `Raise` / `Repository.Save` stamping, it matches the stream’s `Entity.Area`). `GetSpaces()` is the compatibility contract and remains the required method on `DomainEvent` for now. New event types should also implement `GetAreas()`; when present, the package prefers `GetAreas()` for wiring checks, and `GetSpaces()` should delegate to it until the next major release.
 
 ### Store
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -52,7 +52,7 @@ type Aggregate interface {
 }
 ```
 
-**`Raise` vs `Audit`:** `Raise` validates `GetAreas()`, stamps metadata for the aggregate’s domain `Entity`, runs registered handlers, and appends to uncommitted events (replayed by `Load`). `Audit` validates that `GetAreas()` includes the domain area, does **not** run handlers, and stages events for an **audit batch stream** only. `Repository.Save` persists pending audits to that stream (or a custom `AuditRouter` target) **before** domain uncommitted events. Persisted audit rows use `EventMetadata.Entity` equal to that **audit batch stream** (new stream `ID`, same `Area` / tenant / scope as the source), so `GetAggregateID()` on an audit event is the batch stream id, not the originating aggregate’s id; tie back to the command or subject using correlation/causation and event payload. `Load` only reads the domain stream; audit streams are never hydrated into the aggregate. See [audit_events.md](audit_events.md) for semantics and philosophy.
+**`Raise` vs `Audit`:** `Raise` validates `GetAreas()`, stamps metadata for the aggregate’s domain `Entity`, runs registered handlers, and appends to uncommitted events (replayed by `Load`). `Audit` validates that `GetAreas()` includes the domain area, does **not** run handlers, and stages events for an **audit batch stream** only. `Repository.Save` persists pending audits to that stream **before** domain uncommitted events. Persisted audit rows use `EventMetadata.Entity` equal to that **audit batch stream** (new stream `ID`, same `Area` / tenant / scope as the source), so `GetAggregateID()` on an audit event is the batch stream id, not the originating aggregate’s id; tie back to the command or subject using correlation/causation and event payload. `Load` only reads the domain stream; audit streams are never hydrated into the aggregate. See [audit_events.md](audit_events.md) for semantics and philosophy.
 
 **`TrimPendingAudits`:** Used internally by `Repository.Save` after each successful audit batch so a later domain failure does not duplicate already-persisted audits on retry. Callers should not need it unless building alternative persistence tooling.
 
@@ -121,13 +121,7 @@ type Repository interface {
     Load(context.Context, Aggregate) error
     Save(context.Context, Aggregate) error
 }
-
-func WithAuditRouter(router AuditRouter) RepositoryOption
-
-type AuditRouter func(ctx context.Context, agg Aggregate, event DomainEvent) (Entity, error)
 ```
-
-`RepositoryOption` is a functional option type accepted by `NewRepository` (for example `WithAuditRouter`).
 
 **Save ordering:** Pending audits are written first (each distinct audit batch `Entity` in order) with `expectedSequence = 0`, then domain uncommitted events. This is not a single cross-stream transaction unless your `Store` implementation provides one. If the domain write fails after audits succeeded, pending audits have already been trimmed from the aggregate; retrying `Save` persists only the domain batch.
 
@@ -186,7 +180,6 @@ func NewRepository(store Store, opts ...RepositoryOption) Repository
 
 **Options:**
 
-- `WithAuditRouter(router)` — supply a custom resolver for audit stream `Entity` values. When omitted, audits use the derived batch `Entity` assigned by `Aggregate.Audit`.
 
 ### NewInMemoryEventStore
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,15 @@
 
 Complete reference documentation for the `es` event sourcing library.
 
+## Documentation map
+
+| Topic | Where |
+|-------|--------|
+| Hub (overview, diagrams, principles) | [docs/README.md](README.md) |
+| Tutorial-style walkthrough | [getting-started.md](getting-started.md) |
+| Audit batch streams, save order, philosophy | [audit_events.md](audit_events.md) |
+| This file | Types, interfaces, snippets |
+
 ## Core Interfaces
 
 ### Aggregate
@@ -31,10 +40,32 @@ type Aggregate interface {
     // Event behavior
     RegisterHandler(string, DomainEventHandler)
     Raise(DomainEvent) error
+    Audit(DomainEvent) error
     Load([]DomainEvent) error
     Commit()
+
+    GetPendingAudits() []PendingAudit
+    DiscardPendingAudits()
+    TrimPendingAudits(n int)
 }
 ```
+
+**`Raise` vs `Audit`:** `Raise` validates `GetAreas()`, stamps metadata for the aggregate’s domain `Entity`, runs registered handlers, and appends to uncommitted events (replayed by `Load`). `Audit` validates that `GetAreas()` includes the domain area, does **not** run handlers, and stages events for an **audit batch stream** only. `Repository.Save` persists pending audits to that stream (or a custom `AuditRouter` target) **before** domain uncommitted events. Persisted audit rows use `EventMetadata.Entity` equal to that **audit batch stream** (new stream `ID`, same `Area` / tenant / scope as the source), so `GetAggregateID()` on an audit event is the batch stream id, not the originating aggregate’s id; tie back to the command or subject using correlation/causation and event payload. `Load` only reads the domain stream; audit streams are never hydrated into the aggregate. See [audit_events.md](audit_events.md) for semantics and philosophy.
+
+**`TrimPendingAudits`:** Used internally by `Repository.Save` after each successful audit batch so a later domain failure does not duplicate already-persisted audits on retry. Callers should not need it unless building alternative persistence tooling.
+
+### PendingAudit
+
+```go
+type PendingAudit struct {
+    Event     DomainEvent
+    Entity    Entity
+    EventID   uuid.UUID
+    Timestamp int64
+}
+```
+
+Staged audit payload and identifiers assigned at `Audit()` time. `Entity` is the **audit batch stream**: a fresh UUID with the source aggregate’s `Area`, `TenantID`, and `Scope`. After `Repository.Save`, each audit event’s `EventMetadata.Entity` matches that stream (not the originating aggregate’s id). Full `EventMetadata` (including per-batch `Sequence`) is applied inside `Repository.Save`.
 
 ### DomainEvent
 
@@ -45,6 +76,8 @@ type DomainEvent interface {
     polymorphic.Polymorphic
     GetAggregateID() uuid.UUID
     GetArea() string
+    GetAreas() []string
+    // Deprecated: use GetAreas
     GetSpaces() []string
     GetTenantID() uuid.UUID
     GetCausationID() uuid.UUID
@@ -58,6 +91,8 @@ type DomainEvent interface {
 }
 ```
 
+**`GetArea`, `GetAreas`, and deprecated `GetSpaces`:** `GetArea()` reflects the aggregate **area** on the event’s current metadata (after `Raise` / `Repository.Save` stamping, it matches the stream’s `Entity.Area`). `GetAreas()` is the **wiring list**: every event type must return at least the aggregate area(s) where `Raise` and `Audit` are allowed; the default aggregate checks that the aggregate’s `Entity.Area` appears in that slice. `GetSpaces()` must return the same values as `GetAreas()` and exists only for backward compatibility—delegate `GetSpaces()` to `GetAreas()` on new code.
+
 ### Store
 
 Interface for event persistence.
@@ -69,18 +104,40 @@ type Store interface {
 }
 ```
 
+**Implementing `Store` outside this module:** Production adapters (SQL, EventStoreDB, cloud logs, etc.) belong in **your** codebase or infrastructure libraries, not in `es`. The contract callers rely on:
+
+- **`SaveEvents`** — append-only semantics for the given `Entity` (stream key); `expectedSequence` is the number of events already committed on that stream before this append (the in-memory store rejects gaps or mismatches with `ErrConcurrency`).
+- **Audit batch streams** — each new batch stream is written with `expectedSequence == 0` (empty stream). Domain streams use `expectedSequence ==` committed length as today.
+- **Cross-stream atomicity** — the `Store` interface does not require a transaction across different `Entity` values; `Repository.Save` calls `SaveEvents` multiple times when audits and domain events are both present unless your store layers a unit of work on top.
+
 ### Repository
 
 High-level interface for aggregate operations.
 
-Repository implementations emit OpenTelemetry spans for `Load` and `Save` operations. The spans include aggregate identity attributes, scope information, correlation and causation IDs when present in the incoming context, and event or sequence counts relevant to the operation.
+Repository implementations emit OpenTelemetry spans for `Load` and `Save` operations. The spans include aggregate identity attributes, scope information, correlation and causation IDs when present in the incoming context, and event or sequence counts relevant to the operation. `Save` also emits `es.repository.save_audit` child spans per audit stream batch.
 
 ```go
 type Repository interface {
     Load(context.Context, Aggregate) error
     Save(context.Context, Aggregate) error
 }
+
+func WithAuditRouter(router AuditRouter) RepositoryOption
+
+type AuditRouter func(ctx context.Context, agg Aggregate, event DomainEvent) (Entity, error)
 ```
+
+`RepositoryOption` is a functional option type accepted by `NewRepository` (for example `WithAuditRouter`).
+
+**Save ordering:** Pending audits are written first (each distinct audit batch `Entity` in order) with `expectedSequence = 0`, then domain uncommitted events. This is not a single cross-stream transaction unless your `Store` implementation provides one. If the domain write fails after audits succeeded, pending audits have already been trimmed from the aggregate; retrying `Save` persists only the domain batch.
+
+### AuditStreamEntity
+
+```go
+func AuditStreamEntity(domain Entity) Entity
+```
+
+Returns a new **audit batch stream** identity: fresh `ID`, same `Area`, `TenantID`, and `Scope` as the domain aggregate. `Aggregate.Audit` assigns one batch stream per pending audit batch and `Repository.Save` writes that batch with `expectedSequence = 0`.
 
 ## Factory Functions
 
@@ -121,11 +178,15 @@ Typical panic conditions are a nil tenant ID, a nil aggregate ID, or an empty ar
 
 ### NewRepository
 
-Creates a new repository with the given event store.
+Creates a new repository with the given event store and optional configuration.
 
 ```go
-func NewRepository(store Store) Repository
+func NewRepository(store Store, opts ...RepositoryOption) Repository
 ```
+
+**Options:**
+
+- `WithAuditRouter(router)` — supply a custom resolver for audit stream `Entity` values. When omitted, audits use the derived batch `Entity` assigned by `Aggregate.Audit`.
 
 ### NewInMemoryEventStore
 
@@ -170,6 +231,14 @@ Creates a new context with tracing information from a domain event.
 
 ```go
 func WithEventMetadata(ctx context.Context, event DomainEvent) context.Context
+```
+
+### ContextWithTracing
+
+Attaches correlation and causation UUIDs to a context. Repository spans read these values when present (see `GetCorrelationID` / `GetCausationID` in `tracing.go`).
+
+```go
+func ContextWithTracing(ctx context.Context, correlationID, causationID uuid.UUID) context.Context
 ```
 
 ## Types
@@ -284,7 +353,7 @@ func NewTenantEntity(tenantID, id uuid.UUID, area string) Entity
 
 ### NewTenantEntityInArea
 
-Creates a new tenant-scoped entity with a generated ID.
+Creates a new tenant-scoped entity with a generated entity ID in the specified area. Use `NewTenantEntity` when you need to supply the entity id yourself.
 
 ```go
 func NewTenantEntityInArea(tenantID, id uuid.UUID, area string) Entity
@@ -322,7 +391,13 @@ func (a *MyAggregate) DoSomething(param string) error {
     if param == "" {
         return errors.New("param cannot be empty")
     }
-    
+
+    // Optional: stage audit on a derived batch stream. GetAreas on audit events
+    // must include the domain area.
+    if err := a.Audit(&SomethingAudited{Param: param}); err != nil {
+        return err
+    }
+
     // Raise domain event
     return a.Raise(&SomethingDone{Param: param})
 }

--- a/docs/audit_events.md
+++ b/docs/audit_events.md
@@ -26,7 +26,7 @@ Pre-assigning identity fields preserves **causal ordering**, **stable references
 
 Audits are **not** appended to the originating aggregate’s `Entity` (`ID` = business root). Each **pending audit batch** is persisted as its own **short-lived stream** (append partition):
 
-- **`Area`**, **`TenantID`**, and **`Scope`** match the source aggregate (same type space / tenancy as the command).
+- **`Area`**, **`TenantID`**, and **`Scope`** match the source aggregate (same area and tenancy as the command).
 - **`ID`** is a **new UUID** (`uuid.New()`), created when the first `Audit()` runs after the previous batch was flushed (see `AuditStreamEntity` in `entity.go` and `aggregateBase.Audit` in `aggregate.go`).
 - Multiple `Audit()` calls before the next successful `Save()` share **one** batch stream `Entity` (one stream id).
 

--- a/docs/audit_events.md
+++ b/docs/audit_events.md
@@ -1,0 +1,117 @@
+# Audit events
+
+This document describes how **audit** works in `es` today: staging on the aggregate, persistence, stream identity, and how that differs from **domain** events raised with `Raise`.
+
+## Goals
+
+- Record immutable facts (`DomainEvent`) from a command without growing the **domain** aggregate’s replay stream.
+- Allow **concurrent** audit writers without contending on one long-lived audit stream per business aggregate.
+- Keep audit payloads as normal **`DomainEvent`** types (same interface, polymorphic serialization, consumer pipelines).
+
+## Staging: `Audit` vs `Raise`
+
+| | `Raise` | `Audit` |
+|---|---------|---------|
+| Validated against aggregate area | Yes (`GetAreas()` must include `Entity.Area`) | Yes (same rule) |
+| Runs registered handlers | Yes | **No** |
+| Goes into uncommitted / committed | Yes | **No** |
+| Replayed by `Load` | Yes (domain stream only) | **No** |
+| Buffered | `uncommitted` | `pendingAudits` (`[]PendingAudit`) |
+
+Each `PendingAudit` holds the event pointer, a pre-assigned **`EventID`** and **`Timestamp`** (assigned at `Audit()` time, not at save time), and the **`Entity` of the audit batch stream** (see below). Full `EventMetadata` is applied in `Repository.Save`, not at `Audit()` time.
+
+Pre-assigning identity fields preserves **causal ordering**, **stable references** across retries, and avoids retry-time identity drift when the same staged event is persisted after a transient failure.
+
+## Audit batch stream (not a second “domain aggregate”)
+
+Audits are **not** appended to the originating aggregate’s `Entity` (`ID` = business root). Each **pending audit batch** is persisted as its own **short-lived stream** (append partition):
+
+- **`Area`**, **`TenantID`**, and **`Scope`** match the source aggregate (same type space / tenancy as the command).
+- **`ID`** is a **new UUID** (`uuid.New()`), created when the first `Audit()` runs after the previous batch was flushed (see `AuditStreamEntity` in `entity.go` and `aggregateBase.Audit` in `aggregate.go`).
+- Multiple `Audit()` calls before the next successful `Save()` share **one** batch stream `Entity` (one stream id).
+
+That model gives **append locality**, **no long-lived OCC hotspot** on a single audit tail, **bounded stream size per batch** (typically one `Save` worth of events), and **natural parallelism** across concurrent commands (each batch gets its own stream id).
+
+Terminology: prefer **audit batch stream** or **audit append stream** over “derived audit aggregate” — audits are not replayed into aggregate state; the name is stream/partition oriented, not DDD aggregate semantics.
+
+On a persisted audit row, **`GetAggregateID()` / `GetEntity()` identify that audit batch stream**, not the business root. That is **metadata honesty**: the store partition and the event envelope agree. Tie an audit fact back to the business entity using **correlation / causation** and **payload fields** (e.g. subject id), not by overloading `GetAggregateID()`.
+
+## Philosophy: what an audit row means
+
+**`Audit()` is valid even if the command later fails** — including failures before any domain event is raised, or after audits are already staged. That supports high-value records such as denied access, failed validation, rejected workflows, suspicious behavior, or partial external failures.
+
+**Default save order is audits before domain.** Roughly:
+
+- An **audit append may exist without** a successful domain append (e.g. domain `SaveEvents` fails after audit batches succeeded).
+- A **domain append does not run until** pending audit batches for that `Save` have been written successfully (for that call).
+
+Treat persisted audits as **observational facts about what was attempted or observed**, not as a guarantee that a **committed business transition** occurred. If you need “domain definitely committed,” correlate audit rows with successful domain stream positions, outbox completion, or application-level markers — do not infer it from audit presence alone.
+
+## Persistence: `Repository.Save`
+
+The library does not ship database or cloud **`Store`** implementations—only the interface and an in-memory implementation for tests. Your adapter is responsible for append semantics and concurrency per stream. See the **Implementing `Store` outside this module** section in [api-reference.md](api-reference.md).
+
+1. **Snapshot** pending audits (`GetPendingAudits()`).
+2. **Group** staged items by resolved stream `Entity` (default: `PendingAudit.Entity`; with `WithAuditRouter`, see below).
+3. For each batch, in order:
+   - Stamp `EventMetadata` with `Entity =` that batch’s stream `Entity`, sequences `1..n` within the batch, plus correlation/causation and the staged `EventID` / `Timestamp`.
+   - **`SaveEvents(ctx, auditEntity, events, expectedSequence=0)`** — no prior `LoadEvents` on the audit stream; each batch stream starts empty.
+   - On success, **`TrimPendingAudits(n)`** removes the persisted prefix from the in-memory buffer.
+4. Then persist **domain** uncommitted events to `agg.GetEntity()` with normal optimistic concurrency (`expectedSequence = committed length`).
+5. On full success: **`Commit()`** (domain) and **`DiscardPendingAudits()`** (clears any remainder).
+
+There is **no** cross-stream transaction in the default `Store` API unless your implementation provides one.
+
+## Optional routing: `WithAuditRouter`
+
+`NewRepository(store, es.WithAuditRouter(fn))` supplies an `AuditRouter`:
+
+```go
+func(ctx context.Context, agg Aggregate, event DomainEvent) (Entity, error)
+```
+
+**Infrastructure owns topology** (where batches land); **aggregates own behavior** (what gets staged). When the router is set, it **replaces** the default batch `Entity` carried on `PendingAudit` for grouping and persistence. When unset, persistence uses the `Entity` assigned at `Audit()` time.
+
+## Consumers: “like a domain event”
+
+Audit rows are still **`DomainEvent`**:
+
+- Same metadata envelope shape, discriminators, JSON polymorphism, buses, etc.
+- **`GetAggregateID()` is the audit batch stream id**, not the originating business aggregate id — do not assume they match.
+- **`Sequence`** is **within the audit batch stream** (1..n for that `Save`), not the domain aggregate’s global position.
+
+Linking strategies:
+
+- **Tracing:** `CorrelationID` / `CausationID` on the event match the aggregate at save time.
+- **Payload:** include subject ids (e.g. originating aggregate id) in the audit event type when projections need them.
+
+## `Load` and replay (invariant)
+
+**Audit batch streams are never hydrated into the aggregate.** `Repository.Load` only reads **`agg.GetEntity()`** (the domain stream). That invariant is what keeps **replay purity** and prevents audit volume from affecting aggregate reconstruction.
+
+Rebuilding read models from audit data is separate: subscribe to or query the audit batch stream keys your application emits.
+
+## Operational notes
+
+- **`DiscardPendingAudits` / `TrimPendingAudits`** are on the public `Aggregate` interface because `Repository.Save` must trim after partial multi-batch audit writes; application code should not call them except in advanced tooling.
+- **`Commit()`** does not clear pending audits; only `Save` + discard/trim does.
+
+### `SetMetadata` and retries
+
+**`DomainEventBase.SetMetadata` only applies once** when metadata is still empty. That means:
+
+- Successful identity fields on a staged event are **stable** across retries (good for dedupe and references).
+- A `Save` failure **after** metadata was stamped on in-memory pointers but **before** the store acknowledged persistence needs **disciplined** retry behavior from the **store**: ambiguous partial writes, timeouts after success, or non-idempotent retries can desynchronize process memory and storage.
+
+Stricter stores (append-is-atomic, clear OCC rules) keep this manageable; weaker ones may eventually need **idempotent append keys**, **append tokens**, or **dedupe** at the storage layer. The library does not prescribe that today.
+
+## Future consideration: explicit event classification
+
+For indexing, retention, warehousing, subscriptions, and export pipelines, some teams add an explicit **kind** or **classification** on metadata (e.g. domain vs audit), instead of inferring intent only from stream layout or discriminators. That is **not** part of `EventMetadata` in `es` yet; if you need it, encode it in payload conventions or extend your own envelope until a first-class field exists.
+
+## Related code
+
+- `aggregate.go` — `Audit`, `PendingAudit`, `GetPendingAudits`, `TrimPendingAudits`, `DiscardPendingAudits`
+- `repository.go` — `Save`, `AuditRouter`, `WithAuditRouter`, batch grouping
+- `entity.go` — `AuditStreamEntity`
+- `tracing.go` — `es.repository.save_audit` span name

--- a/docs/audit_events.md
+++ b/docs/audit_events.md
@@ -52,7 +52,7 @@ Treat persisted audits as **observational facts about what was attempted or obse
 The library does not ship database or cloud **`Store`** implementations—only the interface and an in-memory implementation for tests. Your adapter is responsible for append semantics and concurrency per stream. See the **Implementing `Store` outside this module** section in [api-reference.md](api-reference.md).
 
 1. **Snapshot** pending audits (`GetPendingAudits()`).
-2. **Group** staged items by resolved stream `Entity` (default: `PendingAudit.Entity`; with `WithAuditRouter`, see below).
+2. **Group** staged items by stream `Entity`.
 3. For each batch, in order:
    - Stamp `EventMetadata` with `Entity =` that batch’s stream `Entity`, sequences `1..n` within the batch, plus correlation/causation and the staged `EventID` / `Timestamp`.
    - **`SaveEvents(ctx, auditEntity, events, expectedSequence=0)`** — no prior `LoadEvents` on the audit stream; each batch stream starts empty.
@@ -61,16 +61,6 @@ The library does not ship database or cloud **`Store`** implementations—only t
 5. On full success: **`Commit()`** (domain) and **`DiscardPendingAudits()`** (clears any remainder).
 
 There is **no** cross-stream transaction in the default `Store` API unless your implementation provides one.
-
-## Optional routing: `WithAuditRouter`
-
-`NewRepository(store, es.WithAuditRouter(fn))` supplies an `AuditRouter`:
-
-```go
-func(ctx context.Context, agg Aggregate, event DomainEvent) (Entity, error)
-```
-
-**Infrastructure owns topology** (where batches land); **aggregates own behavior** (what gets staged). When the router is set, it **replaces** the default batch `Entity` carried on `PendingAudit` for grouping and persistence. When unset, persistence uses the `Entity` assigned at `Audit()` time.
 
 ## Consumers: “like a domain event”
 
@@ -112,6 +102,6 @@ For indexing, retention, warehousing, subscriptions, and export pipelines, some 
 ## Related code
 
 - `aggregate.go` — `Audit`, `PendingAudit`, `GetPendingAudits`, `TrimPendingAudits`, `DiscardPendingAudits`
-- `repository.go` — `Save`, `AuditRouter`, `WithAuditRouter`, batch grouping
+- `repository.go` — `Save`, batch grouping
 - `entity.go` — `AuditStreamEntity`
 - `tracing.go` — `es.repository.save_audit` span name

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide will walk you through building your first event-sourced application u
 
 ## Prerequisites
 
-- Go 1.21 or later
+- Go 1.25 or later (see the `go` directive in this library’s `go.mod` for the exact minimum)
 - Basic understanding of event sourcing concepts
 - Familiarity with Go interfaces and structs
 
@@ -38,7 +38,8 @@ type AccountOpened struct {
 }
 
 func (e *AccountOpened) GetDiscriminator() string { return "account.opened" }
-func (e *AccountOpened) GetSpaces() []string      { return []string{"bank-accounts"} }
+func (e *AccountOpened) GetAreas() []string         { return []string{"bank-accounts"} }
+func (e *AccountOpened) GetSpaces() []string        { return e.GetAreas() }
 
 type MoneyDeposited struct {
     es.DomainEventBase
@@ -46,7 +47,8 @@ type MoneyDeposited struct {
 }
 
 func (e *MoneyDeposited) GetDiscriminator() string { return "money.deposited" }
-func (e *MoneyDeposited) GetSpaces() []string      { return []string{"bank-accounts"} }
+func (e *MoneyDeposited) GetAreas() []string         { return []string{"bank-accounts"} }
+func (e *MoneyDeposited) GetSpaces() []string        { return e.GetAreas() }
 
 type MoneyWithdrawn struct {
     es.DomainEventBase
@@ -54,8 +56,11 @@ type MoneyWithdrawn struct {
 }
 
 func (e *MoneyWithdrawn) GetDiscriminator() string { return "money.withdrawn" }
-func (e *MoneyWithdrawn) GetSpaces() []string      { return []string{"bank-accounts"} }
+func (e *MoneyWithdrawn) GetAreas() []string         { return []string{"bank-accounts"} }
+func (e *MoneyWithdrawn) GetSpaces() []string        { return e.GetAreas() }
 ```
+
+Each event type implements **`GetAreas()`** for `Raise` / `Audit` wiring checks. **`GetSpaces()`** is deprecated and should return the same slice as `GetAreas()` until you drop legacy callers. After events are raised and saved, **`GetArea()`** (from `DomainEventBase`) reflects the area on stamped metadata. For audit-only facts that must not affect replay, see [Audit events](audit_events.md).
 
 ## Step 2: Create Your Aggregate
 
@@ -178,9 +183,9 @@ import (
 )
 
 func main() {
-    // Create event store and repository
+    // In-memory store is for tests and local dev; production Store implementations live in your repo.
     store := es.NewInMemoryEventStore()
-    repo := es.NewRepository(store)
+    repo := es.NewRepository(store) // optional: es.WithAuditRouter(...) — see API reference
     
     // Create a new bank account
     aggregateID := uuid.New()
@@ -273,10 +278,11 @@ func TestShouldReturnErrorWhenWithdrawingMoreThanBalance(t *testing.T) {
 }
 ```
 
-## Next Steps
+## Next steps
 
-- Explore advanced features like multi-tenancy
-- Implement custom event stores for persistence
-- Add event publishing for integration with other systems
-- Consider event versioning strategies for schema evolution
-- Learn about projections and read models for queries
+- Read the [documentation hub](README.md) for architecture, terminology, and links.
+- Use the [API reference](api-reference.md) while wiring `Store`, `Repository`, and tracing helpers.
+- If you record **audit** facts with `Audit`, read [Audit events](audit_events.md) (save order, batch streams, metadata).
+- Multi-tenancy: `NewTenantAggregate` / `NewTenantEntity` (see [API reference](api-reference.md#newtenantaggregate)).
+- Persistence: implement `Store` against your database or event log; keep append semantics and optimistic concurrency aligned with `SaveEvents`.
+- Integrations: publish from your store or outbox; consider schema evolution and projections in your application layer.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -185,7 +185,7 @@ import (
 func main() {
     // In-memory store is for tests and local dev; production Store implementations live in your repo.
     store := es.NewInMemoryEventStore()
-    repo := es.NewRepository(store) // optional: es.WithAuditRouter(...) — see API reference
+    repo := es.NewRepository(store)
     
     // Create a new bank account
     aggregateID := uuid.New()

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -60,7 +60,7 @@ func (e *MoneyWithdrawn) GetAreas() []string         { return []string{"bank-acc
 func (e *MoneyWithdrawn) GetSpaces() []string        { return e.GetAreas() }
 ```
 
-Each event type implements **`GetAreas()`** for `Raise` / `Audit` wiring checks. **`GetSpaces()`** is deprecated and should return the same slice as `GetAreas()` until you drop legacy callers. After events are raised and saved, **`GetArea()`** (from `DomainEventBase`) reflects the area on stamped metadata. For audit-only facts that must not affect replay, see [Audit events](audit_events.md).
+Each event type should implement **`GetAreas()`** for `Raise` / `Audit` wiring checks. **`GetSpaces()`** remains the compatibility method required by `DomainEvent`; it should delegate to `GetAreas()` until you drop legacy callers in a major release. After events are raised and saved, **`GetArea()`** (from `DomainEventBase`) reflects the area on stamped metadata. For audit-only facts that must not affect replay, see [Audit events](audit_events.md).
 
 ## Step 2: Create Your Aggregate
 

--- a/domain_event.go
+++ b/domain_event.go
@@ -11,6 +11,11 @@ type DomainEvent interface {
 	polymorphic.Polymorphic
 	GetAggregateID() uuid.UUID
 	GetArea() string
+	// GetAreas returns aggregate area names this event type may be used with (Raise/Audit wiring).
+	GetAreas() []string
+	// GetSpaces returns the same values as GetAreas.
+	//
+	// Deprecated: use GetAreas instead.
 	GetSpaces() []string
 	GetTenantID() uuid.UUID
 	GetCausationID() uuid.UUID

--- a/domain_event.go
+++ b/domain_event.go
@@ -11,11 +11,8 @@ type DomainEvent interface {
 	polymorphic.Polymorphic
 	GetAggregateID() uuid.UUID
 	GetArea() string
-	// GetAreas returns aggregate area names this event type may be used with (Raise/Audit wiring).
-	GetAreas() []string
-	// GetSpaces returns the same values as GetAreas.
+	// GetSpaces returns aggregate area names this event type may be used with (Raise/Audit wiring).
 	//
-	// Deprecated: use GetAreas instead.
 	GetSpaces() []string
 	GetTenantID() uuid.UUID
 	GetCausationID() uuid.UUID
@@ -26,6 +23,18 @@ type DomainEvent interface {
 	GetSequence() uint64
 	GetTimestamp() int64
 	SetMetadata(metadata EventMetadata)
+}
+
+type areaLister interface {
+	GetAreas() []string
+}
+
+func eventAreas(event DomainEvent) []string {
+	if lister, ok := any(event).(areaLister); ok {
+		return lister.GetAreas()
+	}
+
+	return event.GetSpaces()
 }
 
 // EventMetadata contains the metadata fields common to all domain events.

--- a/domain_event_test.go
+++ b/domain_event_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 type MockEntity struct {
-	ID    uuid.UUID
-	Space string
+	ID   uuid.UUID
+	Area string
 }
 
 func TestDomainEventBase(t *testing.T) {
@@ -37,7 +37,7 @@ func TestDomainEventBase(t *testing.T) {
 		assert.Equal(t, metadata.Entity.ID, event.GetAggregateID())
 	})
 
-	t.Run("GetAggregateSpace", func(t *testing.T) {
+	t.Run("GetArea", func(t *testing.T) {
 		assert.Equal(t, metadata.Entity.Area, event.GetArea())
 	})
 

--- a/entity.go
+++ b/entity.go
@@ -44,6 +44,18 @@ func NewTenantEntityInArea(tenantID, id uuid.UUID, area string) Entity {
 	}
 }
 
+// AuditStreamEntity returns a new default audit stream identity derived from a domain aggregate.
+// It shares Area, TenantID, and Scope with the domain entity, but uses a fresh ID so
+// each audit batch is an independent stream.
+func AuditStreamEntity(domain Entity) Entity {
+	return Entity{
+		ID:       uuid.New(),
+		Area:     domain.Area,
+		TenantID: domain.TenantID,
+		Scope:    domain.Scope,
+	}
+}
+
 // EmptyEntity represents an uninitialized entity.
 var EmptyEntity = Entity{}
 

--- a/entity_test.go
+++ b/entity_test.go
@@ -80,28 +80,28 @@ func TestShouldCreateAuditStreamEntityWithGeneratedIDAndSameArea(t *testing.T) {
 	assert.Equal(t, domain.Scope, audit.Scope)
 }
 
-func TestShouldReturnCorrectSpaceForGlobalEntity(t *testing.T) {
+func TestShouldReturnCorrectAreaForGlobalEntity(t *testing.T) {
 	// Arrange
 	entity := NewEntity(uuid.New(), "test-area")
 
 	// Act
-	space := entity.Area
+	area := entity.Area
 
 	// Assert
-	assert.Equal(t, "test-area", space)
+	assert.Equal(t, "test-area", area)
 }
 
-func TestShouldReturnCorrectSpaceForTenantEntity(t *testing.T) {
+func TestShouldReturnCorrectAreaForTenantEntity(t *testing.T) {
 	// Arrange
 	tenantID := uuid.New()
 	entity := NewTenantEntity(tenantID, uuid.New(), "test-area")
 
 	// Act
-	space := entity.Area
+	area := entity.Area
 
 	// Assert
 	expected := "test-area"
-	assert.Equal(t, expected, space)
+	assert.Equal(t, expected, area)
 }
 
 func TestShouldDetectEmptyEntity(t *testing.T) {

--- a/entity_test.go
+++ b/entity_test.go
@@ -68,6 +68,18 @@ func TestShouldCreateTenantEntityInAreaWithGeneratedID(t *testing.T) {
 	assert.Equal(t, tenantID, entity.TenantID)
 }
 
+func TestShouldCreateAuditStreamEntityWithGeneratedIDAndSameArea(t *testing.T) {
+	domain := NewTenantEntity(uuid.New(), uuid.New(), "users")
+
+	audit := AuditStreamEntity(domain)
+
+	assert.NotEqual(t, uuid.Nil, audit.ID)
+	assert.NotEqual(t, domain.ID, audit.ID)
+	assert.Equal(t, domain.Area, audit.Area)
+	assert.Equal(t, domain.TenantID, audit.TenantID)
+	assert.Equal(t, domain.Scope, audit.Scope)
+}
+
 func TestShouldReturnCorrectSpaceForGlobalEntity(t *testing.T) {
 	// Arrange
 	entity := NewEntity(uuid.New(), "test-area")

--- a/mock_domain_event.go
+++ b/mock_domain_event.go
@@ -8,8 +8,12 @@ func (m *mockDomainEvent) GetDiscriminator() string {
 	return "es://mock_domain_event"
 }
 
-func (m *mockDomainEvent) GetSpaces() []string {
+func (m *mockDomainEvent) GetAreas() []string {
 	return []string{"test-area"}
+}
+
+func (m *mockDomainEvent) GetSpaces() []string {
+	return m.GetAreas()
 }
 
 // Optionally, implement other DomainEvent methods as needed for tests.

--- a/repository.go
+++ b/repository.go
@@ -8,21 +8,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
-// AuditRouter resolves the event store entity for a staged audit event.
-// When set on Repository via WithAuditRouter, it replaces the default AuditStreamEntity routing.
-type AuditRouter func(ctx context.Context, agg Aggregate, event DomainEvent) (Entity, error)
-
-// RepositoryOption configures Repository construction.
-type RepositoryOption func(*repository)
-
-// WithAuditRouter sets a custom audit stream resolver. When nil (default),
-// audit events use the derived batch stream assigned by Aggregate.Audit.
-func WithAuditRouter(router AuditRouter) RepositoryOption {
-	return func(r *repository) {
-		r.auditRouter = router
-	}
-}
-
 // Repository provides high-level operations for loading and saving aggregates.
 // It coordinates between aggregates and the underlying event store.
 type Repository interface {
@@ -30,22 +15,17 @@ type Repository interface {
 	Load(context.Context, Aggregate) error
 
 	// Save persists uncommitted domain events and pending audit events.
-	// Audit streams are written first (derived batch entity or AuditRouter), then the domain stream.
+	// Audit streams are written first, then the domain stream.
 	Save(context.Context, Aggregate) error
 }
 
 type repository struct {
-	store       Store
-	auditRouter AuditRouter
+	store Store
 }
 
-// NewRepository creates a new repository with the given event store and optional configuration.
-func NewRepository(store Store, opts ...RepositoryOption) Repository {
-	r := &repository{store: store}
-	for _, o := range opts {
-		o(r)
-	}
-	return r
+// NewRepository creates a new repository with the given event store.
+func NewRepository(store Store) Repository {
+	return &repository{store: store}
 }
 
 func (r *repository) Load(ctx context.Context, a Aggregate) error {
@@ -93,12 +73,7 @@ func (r *repository) Save(ctx context.Context, a Aggregate) error {
 		return nil
 	}
 
-	batches, err := groupPendingAuditsByStream(ctx, r, a, pending)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		return err
-	}
+	batches := groupPendingAuditsByStream(pending)
 
 	for _, batch := range batches {
 		auditEntity := batch.entity
@@ -119,7 +94,7 @@ func (r *repository) Save(ctx context.Context, a Aggregate) error {
 			events = append(events, pa.Event)
 		}
 
-		err = r.store.SaveEvents(ctxAudit, auditEntity, events, 0)
+		err := r.store.SaveEvents(ctxAudit, auditEntity, events, 0)
 		if err != nil {
 			spanAudit.RecordError(err)
 			spanAudit.SetStatus(codes.Error, err.Error())
@@ -151,17 +126,14 @@ type auditStreamBatch struct {
 	items  []PendingAudit
 }
 
-func groupPendingAuditsByStream(ctx context.Context, r *repository, a Aggregate, pending []PendingAudit) ([]auditStreamBatch, error) {
+func groupPendingAuditsByStream(pending []PendingAudit) []auditStreamBatch {
 	if len(pending) == 0 {
-		return nil, nil
+		return nil
 	}
 	batchesByEntity := make(map[Entity]int)
 	var batches []auditStreamBatch
 	for _, pa := range pending {
-		ent, err := r.resolveAuditEntity(ctx, a, pa)
-		if err != nil {
-			return nil, err
-		}
+		ent := pa.Entity
 		if index, exists := batchesByEntity[ent]; exists {
 			batches[index].items = append(batches[index].items, pa)
 			continue
@@ -170,12 +142,5 @@ func groupPendingAuditsByStream(ctx context.Context, r *repository, a Aggregate,
 		batchesByEntity[ent] = len(batches)
 		batches = append(batches, auditStreamBatch{entity: ent, items: []PendingAudit{pa}})
 	}
-	return batches, nil
-}
-
-func (r *repository) resolveAuditEntity(ctx context.Context, a Aggregate, audit PendingAudit) (Entity, error) {
-	if r.auditRouter != nil {
-		return r.auditRouter(ctx, a, audit.Event)
-	}
-	return audit.Entity, nil
+	return batches
 }

--- a/repository.go
+++ b/repository.go
@@ -155,17 +155,20 @@ func groupPendingAuditsByStream(ctx context.Context, r *repository, a Aggregate,
 	if len(pending) == 0 {
 		return nil, nil
 	}
+	batchesByEntity := make(map[Entity]int)
 	var batches []auditStreamBatch
 	for _, pa := range pending {
 		ent, err := r.resolveAuditEntity(ctx, a, pa)
 		if err != nil {
 			return nil, err
 		}
-		if len(batches) > 0 && batches[len(batches)-1].entity == ent {
-			batches[len(batches)-1].items = append(batches[len(batches)-1].items, pa)
-		} else {
-			batches = append(batches, auditStreamBatch{entity: ent, items: []PendingAudit{pa}})
+		if index, exists := batchesByEntity[ent]; exists {
+			batches[index].items = append(batches[index].items, pa)
+			continue
 		}
+
+		batchesByEntity[ent] = len(batches)
+		batches = append(batches, auditStreamBatch{entity: ent, items: []PendingAudit{pa}})
 	}
 	return batches, nil
 }

--- a/repository.go
+++ b/repository.go
@@ -8,23 +8,44 @@ import (
 	"go.opentelemetry.io/otel/codes"
 )
 
+// AuditRouter resolves the event store entity for a staged audit event.
+// When set on Repository via WithAuditRouter, it replaces the default AuditStreamEntity routing.
+type AuditRouter func(ctx context.Context, agg Aggregate, event DomainEvent) (Entity, error)
+
+// RepositoryOption configures Repository construction.
+type RepositoryOption func(*repository)
+
+// WithAuditRouter sets a custom audit stream resolver. When nil (default),
+// audit events use the derived batch stream assigned by Aggregate.Audit.
+func WithAuditRouter(router AuditRouter) RepositoryOption {
+	return func(r *repository) {
+		r.auditRouter = router
+	}
+}
+
 // Repository provides high-level operations for loading and saving aggregates.
 // It coordinates between aggregates and the underlying event store.
 type Repository interface {
 	// Load reconstructs an aggregate from its stored events.
 	Load(context.Context, Aggregate) error
 
-	// Save persists uncommitted events from an aggregate to the store.
+	// Save persists uncommitted domain events and pending audit events.
+	// Audit streams are written first (derived batch entity or AuditRouter), then the domain stream.
 	Save(context.Context, Aggregate) error
 }
 
 type repository struct {
-	store Store
+	store       Store
+	auditRouter AuditRouter
 }
 
-// NewRepository creates a new repository with the given event store.
-func NewRepository(store Store) Repository {
-	return &repository{store: store}
+// NewRepository creates a new repository with the given event store and optional configuration.
+func NewRepository(store Store, opts ...RepositoryOption) Repository {
+	r := &repository{store: store}
+	for _, o := range opts {
+		o(r)
+	}
+	return r
 }
 
 func (r *repository) Load(ctx context.Context, a Aggregate) error {
@@ -54,28 +75,104 @@ func (r *repository) Load(ctx context.Context, a Aggregate) error {
 func (r *repository) Save(ctx context.Context, a Aggregate) error {
 	entity := a.GetEntity()
 	uncommitted := a.GetUncommittedEvents()
+	pending := a.GetPendingAudits()
 	expectedSequence := a.GetCommittedSequence()
+
 	ctx, span := startSpan(
 		ctx,
 		spanRepositorySave,
 		entity,
 		attribute.Int(attributeEventsCount, len(uncommitted)),
+		attribute.Int(attributePendingAuditCount, len(pending)),
 		attribute.String(attributeSequenceExpected, strconv.FormatUint(expectedSequence, 10)),
 		attribute.String(attributeSequenceCurrent, strconv.FormatUint(a.GetUncommittedSequence(), 10)),
 	)
 	defer span.End()
 
-	if len(uncommitted) == 0 {
+	if len(uncommitted) == 0 && len(pending) == 0 {
 		return nil
 	}
 
-	err := r.store.SaveEvents(ctx, entity, uncommitted, expectedSequence)
+	batches, err := groupPendingAuditsByStream(ctx, r, a, pending)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return err
 	}
 
+	for _, batch := range batches {
+		auditEntity := batch.entity
+		ctxAudit, spanAudit := startSpan(ctx, spanRepositorySaveAudit, auditEntity,
+			attribute.Int(attributeEventsCount, len(batch.items)),
+		)
+
+		events := make([]DomainEvent, 0, len(batch.items))
+		for i, pa := range batch.items {
+			pa.Event.SetMetadata(EventMetadata{
+				Entity:        auditEntity,
+				EventID:       pa.EventID,
+				CorrelationID: a.GetCorrelationID(),
+				CausationID:   a.GetCausationID(),
+				Timestamp:     pa.Timestamp,
+				Sequence:      uint64(i) + 1,
+			})
+			events = append(events, pa.Event)
+		}
+
+		err = r.store.SaveEvents(ctxAudit, auditEntity, events, 0)
+		if err != nil {
+			spanAudit.RecordError(err)
+			spanAudit.SetStatus(codes.Error, err.Error())
+			spanAudit.End()
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return err
+		}
+		a.TrimPendingAudits(len(batch.items))
+		spanAudit.End()
+	}
+
+	if len(uncommitted) > 0 {
+		err := r.store.SaveEvents(ctx, entity, uncommitted, expectedSequence)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return err
+		}
+	}
+
 	a.Commit()
+	a.DiscardPendingAudits()
 	return nil
+}
+
+type auditStreamBatch struct {
+	entity Entity
+	items  []PendingAudit
+}
+
+func groupPendingAuditsByStream(ctx context.Context, r *repository, a Aggregate, pending []PendingAudit) ([]auditStreamBatch, error) {
+	if len(pending) == 0 {
+		return nil, nil
+	}
+	var batches []auditStreamBatch
+	for _, pa := range pending {
+		ent, err := r.resolveAuditEntity(ctx, a, pa)
+		if err != nil {
+			return nil, err
+		}
+		if len(batches) > 0 && batches[len(batches)-1].entity == ent {
+			batches[len(batches)-1].items = append(batches[len(batches)-1].items, pa)
+		} else {
+			batches = append(batches, auditStreamBatch{entity: ent, items: []PendingAudit{pa}})
+		}
+	}
+	return batches, nil
+}
+
+func (r *repository) resolveAuditEntity(ctx context.Context, a Aggregate, audit PendingAudit) (Entity, error) {
+	if r.auditRouter != nil {
+		return r.auditRouter(ctx, a, audit.Event)
+	}
+	return audit.Entity, nil
 }

--- a/repository_test.go
+++ b/repository_test.go
@@ -281,6 +281,89 @@ func TestShouldRecordSpanErrorWhenSaveFails(t *testing.T) {
 	mockStore.AssertExpectations(t)
 }
 
+func TestShouldPersistAuditsBeforeDomainStream(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryEventStore()
+	repo := NewRepository(store)
+	dummy := NewDummy()
+	_ = dummy.LogAudit("login")
+	_ = dummy.Create("alice")
+	auditEntity := dummy.GetPendingAudits()[0].Entity
+
+	err := repo.Save(ctx, dummy)
+	assert.NoError(t, err)
+
+	auditEvents, err := store.LoadEvents(ctx, auditEntity, 0)
+	assert.NoError(t, err)
+	domainEvents, err := store.LoadEvents(ctx, dummy.GetEntity(), 0)
+	assert.NoError(t, err)
+	assert.Len(t, auditEvents, 1)
+	assert.Len(t, domainEvents, 1)
+	meta := auditEvents[0].GetMetadata()
+	assert.Equal(t, auditEntity, meta.Entity)
+	assert.Equal(t, uint64(1), meta.Sequence)
+	assert.NotEqual(t, dummy.GetEntity().ID, meta.Entity.ID)
+	assert.Equal(t, dummy.GetEntity().Area, meta.Entity.Area)
+}
+
+func TestShouldSavePendingAuditsWithoutDomainUncommitted(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryEventStore()
+	repo := NewRepository(store)
+	dummy := NewDummy()
+	_ = dummy.LogAudit("peek")
+	auditEntity := dummy.GetPendingAudits()[0].Entity
+
+	err := repo.Save(ctx, dummy)
+	assert.NoError(t, err)
+
+	auditEvents, err := store.LoadEvents(ctx, auditEntity, 0)
+	assert.NoError(t, err)
+	assert.Len(t, auditEvents, 1)
+	domainEvents, err := store.LoadEvents(ctx, dummy.GetEntity(), 0)
+	assert.NoError(t, err)
+	assert.Len(t, domainEvents, 0)
+	assert.Len(t, dummy.GetPendingAudits(), 0)
+}
+
+func TestShouldReturnAuditRouterErrorBeforeWriting(t *testing.T) {
+	ctx := context.Background()
+	store := NewInMemoryEventStore()
+	routerErr := errors.New("routing failed")
+	repo := NewRepository(store, WithAuditRouter(func(ctx context.Context, agg Aggregate, event DomainEvent) (Entity, error) {
+		return Entity{}, routerErr
+	}))
+	dummy := NewDummy()
+	_ = dummy.LogAudit("x")
+
+	err := repo.Save(ctx, dummy)
+	assert.ErrorIs(t, err, routerErr)
+
+	auditEntity := dummy.GetPendingAudits()[0].Entity
+	auditEvents, err := store.LoadEvents(ctx, auditEntity, 0)
+	assert.NoError(t, err)
+	assert.Len(t, auditEvents, 0)
+	assert.Len(t, dummy.GetPendingAudits(), 1)
+}
+
+func TestShouldTrimPendingAuditsWhenDomainSaveFailsAfterAuditPersisted(t *testing.T) {
+	mockStore := new(MockStore)
+	repo := NewRepository(mockStore)
+	dummy := NewDummy()
+	_ = dummy.LogAudit("a")
+	_ = dummy.Create("b")
+
+	auditEnt := dummy.GetPendingAudits()[0].Entity
+	mockStore.On("SaveEvents", mock.Anything, auditEnt, mock.Anything, uint64(0)).Return(nil).Once()
+	domainFail := errors.New("domain failed")
+	mockStore.On("SaveEvents", mock.Anything, dummy.GetEntity(), mock.Anything, uint64(0)).Return(domainFail).Once()
+
+	err := repo.Save(context.Background(), dummy)
+	assert.ErrorIs(t, err, domainFail)
+	assert.Len(t, dummy.GetPendingAudits(), 0)
+	mockStore.AssertExpectations(t)
+}
+
 func TestShouldCreateSpanWhenSaveIsNoOp(t *testing.T) {
 	// Arrange
 	spanRecorder := setupSpanRecorder(t)
@@ -300,6 +383,7 @@ func TestShouldCreateSpanWhenSaveIsNoOp(t *testing.T) {
 	assert.Len(t, spans, 1)
 	assertRepositorySpanAttributes(t, spans[0], spanRepositorySave, dummy.GetEntity(), correlationID, causationID)
 	assertSpanInt64Attribute(t, spans[0], attributeEventsCount, 0)
+	assertSpanInt64Attribute(t, spans[0], attributePendingAuditCount, 0)
 	assertSpanStringAttribute(t, spans[0], attributeSequenceExpected, "0")
 	assertSpanStringAttribute(t, spans[0], attributeSequenceCurrent, "0")
 	assert.Equal(t, codes.Unset, spans[0].Status().Code)

--- a/repository_test.go
+++ b/repository_test.go
@@ -282,6 +282,7 @@ func TestShouldRecordSpanErrorWhenSaveFails(t *testing.T) {
 }
 
 func TestShouldPersistAuditsBeforeDomainStream(t *testing.T) {
+	// Arrange
 	ctx := context.Background()
 	store := NewInMemoryEventStore()
 	repo := NewRepository(store)
@@ -290,7 +291,10 @@ func TestShouldPersistAuditsBeforeDomainStream(t *testing.T) {
 	_ = dummy.Create("alice")
 	auditEntity := dummy.GetPendingAudits()[0].Entity
 
+	// Act
 	err := repo.Save(ctx, dummy)
+
+	// Assert
 	assert.NoError(t, err)
 
 	auditEvents, err := store.LoadEvents(ctx, auditEntity, 0)
@@ -307,6 +311,7 @@ func TestShouldPersistAuditsBeforeDomainStream(t *testing.T) {
 }
 
 func TestShouldSavePendingAuditsWithoutDomainUncommitted(t *testing.T) {
+	// Arrange
 	ctx := context.Background()
 	store := NewInMemoryEventStore()
 	repo := NewRepository(store)
@@ -314,7 +319,10 @@ func TestShouldSavePendingAuditsWithoutDomainUncommitted(t *testing.T) {
 	_ = dummy.LogAudit("peek")
 	auditEntity := dummy.GetPendingAudits()[0].Entity
 
+	// Act
 	err := repo.Save(ctx, dummy)
+
+	// Assert
 	assert.NoError(t, err)
 
 	auditEvents, err := store.LoadEvents(ctx, auditEntity, 0)
@@ -327,6 +335,7 @@ func TestShouldSavePendingAuditsWithoutDomainUncommitted(t *testing.T) {
 }
 
 func TestShouldTrimPendingAuditsWhenDomainSaveFailsAfterAuditPersisted(t *testing.T) {
+	// Arrange
 	mockStore := new(MockStore)
 	repo := NewRepository(mockStore)
 	dummy := NewDummy()
@@ -338,7 +347,10 @@ func TestShouldTrimPendingAuditsWhenDomainSaveFailsAfterAuditPersisted(t *testin
 	domainFail := errors.New("domain failed")
 	mockStore.On("SaveEvents", mock.Anything, dummy.GetEntity(), mock.Anything, uint64(0)).Return(domainFail).Once()
 
+	// Act
 	err := repo.Save(context.Background(), dummy)
+
+	// Assert
 	assert.ErrorIs(t, err, domainFail)
 	assert.Len(t, dummy.GetPendingAudits(), 0)
 	mockStore.AssertExpectations(t)

--- a/repository_test.go
+++ b/repository_test.go
@@ -326,26 +326,6 @@ func TestShouldSavePendingAuditsWithoutDomainUncommitted(t *testing.T) {
 	assert.Len(t, dummy.GetPendingAudits(), 0)
 }
 
-func TestShouldReturnAuditRouterErrorBeforeWriting(t *testing.T) {
-	ctx := context.Background()
-	store := NewInMemoryEventStore()
-	routerErr := errors.New("routing failed")
-	repo := NewRepository(store, WithAuditRouter(func(ctx context.Context, agg Aggregate, event DomainEvent) (Entity, error) {
-		return Entity{}, routerErr
-	}))
-	dummy := NewDummy()
-	_ = dummy.LogAudit("x")
-
-	err := repo.Save(ctx, dummy)
-	assert.ErrorIs(t, err, routerErr)
-
-	auditEntity := dummy.GetPendingAudits()[0].Entity
-	auditEvents, err := store.LoadEvents(ctx, auditEntity, 0)
-	assert.NoError(t, err)
-	assert.Len(t, auditEvents, 0)
-	assert.Len(t, dummy.GetPendingAudits(), 1)
-}
-
 func TestShouldTrimPendingAuditsWhenDomainSaveFailsAfterAuditPersisted(t *testing.T) {
 	mockStore := new(MockStore)
 	repo := NewRepository(mockStore)

--- a/tracing.go
+++ b/tracing.go
@@ -16,18 +16,20 @@ type causationContextKey struct{}
 const tracerName = "github.com/fgrzl/es"
 
 const (
-	spanRepositoryLoad = "es.repository.load"
-	spanRepositorySave = "es.repository.save"
+	spanRepositoryLoad      = "es.repository.load"
+	spanRepositorySave      = "es.repository.save"
+	spanRepositorySaveAudit = "es.repository.save_audit"
 
-	attributeEntityID         = "es.entity.id"
-	attributeEntityArea       = "es.entity.area"
-	attributeEntityScope      = "es.entity.scope"
-	attributeEntityTenantID   = "es.entity.tenant_id"
-	attributeCorrelationID    = "es.correlation_id"
-	attributeCausationID      = "es.causation_id"
-	attributeEventsCount      = "es.events.count"
-	attributeSequenceExpected = "es.sequence.expected"
-	attributeSequenceCurrent  = "es.sequence.current"
+	attributeEntityID          = "es.entity.id"
+	attributeEntityArea        = "es.entity.area"
+	attributeEntityScope       = "es.entity.scope"
+	attributeEntityTenantID    = "es.entity.tenant_id"
+	attributeCorrelationID     = "es.correlation_id"
+	attributeCausationID       = "es.causation_id"
+	attributeEventsCount       = "es.events.count"
+	attributePendingAuditCount = "es.pending_audits.count"
+	attributeSequenceExpected  = "es.sequence.expected"
+	attributeSequenceCurrent   = "es.sequence.current"
 )
 
 // ContextWithTracing adds correlation and causation IDs to the context.


### PR DESCRIPTION
…and tests

- Introduced `Audit` method in the `Aggregate` interface to stage audit events without affecting uncommitted domain events.
- Implemented `PendingAudit` struct to manage staged audit events, including entity and timestamp.
- Updated `Repository.Save` to persist pending audits before domain events, ensuring correct save order.
- Added tests for audit functionality, including scenarios for saving audits and handling errors.
- Refactored event handling to replace deprecated `GetSpaces` with `GetAreas` for better clarity and consistency.
- Enhanced documentation to reflect new audit features and usage patterns.